### PR TITLE
[fix]Bug: Moramo i dalje podrzavati 'admin' kao lozinku 

### DIFF
--- a/app/pages/api/login.js
+++ b/app/pages/api/login.js
@@ -1,7 +1,13 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 
 export default (req, res) => {
-  if (req.body.username === 'admin' && req.body.password === 'admin$2023KAKOE.abcrajak') {
+
+  const dobriKredencijali = (req.body.username === 'admin' && req.body.password === 'admin$2023KAKOE.abcrajak')
+
+  // MORAMO DA OMOGUCIMO DJACIMA KOJI PRATE RANIJA PREDAVANJA DA MOGU I DALJE DA SE ULOGUJU!!!
+  // TAKO da cemo dozvoliti i login sa admin/admin
+  || (req.body.username === 'admin' && req.body.password === 'admin');
+  if (dobriKredencijali) {
     const json = JSON.stringify(
       {
         info: 'LOGIN PROSAO',


### PR DESCRIPTION
# Why 
Bug: Moramo i dalje podrzavati 'admin' kao lozinku, da bi djaci koji prate asinhrono mogli da koriste app 



# What 

omoguceno logovanje sa admin/admin
# How to test 

Otvoriti preview
otici na /ponavljanje-sebatian/index.html

Probati kao korisniko ime 'admin'
Kao  lozinku 'admin'

Trebalo bi da prodje logovanje
